### PR TITLE
Fixed incorrect line number in error message

### DIFF
--- a/Sources/SwiftCompilerDiscordappBot/Sword+extension.swift
+++ b/Sources/SwiftCompilerDiscordappBot/Sword+extension.swift
@@ -77,7 +77,7 @@ extension Message {
         return (options, swiftCode)
     }
 
-    private static let regexForCodeblock = regex(pattern: "```(?:.*?$)?(.*?)```")
+    private static let regexForCodeblock = regex(pattern: "```(?:.*?\n)?(.*?)```")
     private static let regexForMentionedLine = regex(pattern: "<@!?\(App.bot.user!.id)>(.*?)(?:```|$)")
 }
 


### PR DESCRIPTION
`$` does not match Line terminating characters themselves.